### PR TITLE
Correct the normalization for Dakuon and Handakuon

### DIFF
--- a/sig/generated/neologdish/normalizer.rbs
+++ b/sig/generated/neologdish/normalizer.rbs
@@ -9,6 +9,8 @@ module Neologdish
 
     HALF_WIDTH_KANA_MAP: Hash[String, String]
 
+    DAKUON_HANDAKUON_POSSIBLES: Hash[String, bool]
+
     DAKUON_KANA_MAP: Hash[String, String]
 
     HANDAKUON_KANA_MAP: Hash[String, String]
@@ -18,6 +20,6 @@ module Neologdish
     # @rbs str: String
     # @rbs override_conversion_map: Hash[String, String]
     # @rbs return: String
-    def normalize: (String str, ?Hash[String, String] override_conversion_map) -> String
+    def self?.normalize: (String str, ?Hash[String, String] override_conversion_map) -> String
   end
 end

--- a/test/neologdish/test_normalizer.rb
+++ b/test/neologdish/test_normalizer.rb
@@ -37,6 +37,10 @@ module Neologdish
         assert_equal '南アルプスの天然水-Sparking*Lemon+レモン一絞り',
                      Neologdish::Normalizer.normalize('南アルプスの　天然水-　Ｓｐａｒｋｉｎｇ*　Ｌｅｍｏｎ+　レモン一絞り')
         assert_equal 'ツギノ「ヌﾟ」ハオカシナモジデス', Neologdish::Normalizer.normalize('ﾂｷﾞﾉ「ﾇﾟ」ﾊｵｶｼﾅﾓｼﾞﾃﾞｽ')
+        assert_equal 'ばばばぱぱぱ',
+                     Neologdish::Normalizer.normalize("は\u309bは\u3099は\uff9eは\u309cは\u309aは\uff9f")
+        assert_equal 'バババパパパ',
+                     Neologdish::Normalizer.normalize("ハ\u309bハ\u3099ハ\uff9eハ\u309cハ\u309aハ\uff9f")
       end
 
       def test_override_conversion_map


### PR DESCRIPTION
This commit changes following:

- Expand the supported Dakuon characters
  - "\u309b"
  - "\u3099"
- Expand the supported Handakuon characters
  - "\u309c"
  - "\u309a"
- Support Hiragana Dakuon/Handakuon normalizations
- Add supported Dakuon/Handakuon characters:
  - 'ヴ'
  - 'ゔ'